### PR TITLE
feat(yafu): add is function

### DIFF
--- a/modules/yafu/lib/is.js
+++ b/modules/yafu/lib/is.js
@@ -1,0 +1,19 @@
+import curry from './curry'
+export default curry(_is) 
+
+/**
+ * Validates if value has a specific type.
+ * Function is sensitive to NaN and Infinity.
+ *
+ * @function is
+ * @arg {Object} t Type the value needs to be validated against
+ * @arg {*} v Value that needs to be tested
+ * @return {Boolean}
+ * */
+function _is(t, v) {
+  if(t == Number) {
+    if(isNaN(v) || !Number.isFinite(v)) return false
+  }
+
+  return v.constructor === t
+}

--- a/modules/yafu/test/is.js
+++ b/modules/yafu/test/is.js
@@ -1,0 +1,40 @@
+import is from '../lib/is'
+
+module.exports = function() {
+  return function() {
+    it('works with strings', function() {
+      is(String, 'sample text').should.equal(true)
+    })
+
+    it('works with regular numbers', function() {
+      is(Number, 4).should.equal(true)
+      is(Number, -38742384).should.equal(true)
+      is(Number, -1e48).should.equal(true)
+      is(Number, 0).should.equal(true)
+    })
+
+    it('works with hex numbers', function() {
+      is(Number, 0x3B4B3FA000).should.equal(true)
+    })
+
+    it('works with irrational numbers', function() {
+      is(Number, Infinity).should.equal(false)
+    })
+
+    it('works with NaN', function() {
+      is(Number, NaN).should.equal(false)
+    })
+
+    it('works with arrays', function() {
+      is(Object, [ 2, 8, 2 ]).should.equal(false)
+      is(Object, []).should.equal(false)
+
+      is(Array, [ 2, 8, 2 ]).should.equal(true)
+      is(Array, []).should.equal(true)
+    })
+
+    it('works with objects', function() {
+      is(Object, {}).should.equal(true)
+    })
+  }
+}


### PR DESCRIPTION
Better implementation of the `Ramda.is` function. The function is `Infinity` and `NaN` sensitive. It can also correctly check if the value is an object or array.

**Arrays/Objects:**
```
is(Array, []) // > true
is(Object, []) // > false
is(Object, {}) // > true
```

**Numbers:**
```
is(Number, NaN); // > false
is(Number, Infinity); // > false
is(Number, 0x593); // > true
is(Number, 44); // > true
```